### PR TITLE
[PLIN-1306] Handle both string and byte return for JSONB fields

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -121,12 +121,13 @@ func hydrateModel(modelType reflect.Type, values map[string]interface{}) reflect
 
 			if hasValue && reflect.ValueOf(value).IsValid() {
 				if isJSONB {
-					valueString, ok := value.(string)
-					if ok {
-						destinationValue := reflect.New(field.Type).Interface()
-						json.Unmarshal([]byte(valueString), destinationValue)
-						value = reflect.Indirect(reflect.ValueOf(destinationValue)).Interface()
+					valueString, isString := value.(string)
+					if !isString {
+						valueString = string(value.([]byte))
 					}
+					destinationValue := reflect.New(field.Type).Interface()
+					json.Unmarshal([]byte(valueString), destinationValue)
+					value = reflect.Indirect(reflect.ValueOf(destinationValue)).Interface()
 				}
 
 				if reflectedValue.Type().ConvertibleTo(field.Type) {

--- a/filter_test.go
+++ b/filter_test.go
@@ -319,6 +319,28 @@ func TestDoFilterSelectWithJSONBField(t *testing.T) {
 				mock.ExpectBegin()
 				mock.ExpectQuery("^SELECT test_table.test_column_one FROM test_table$").WillReturnRows(
 					sqlmock.NewRows([]string{"test_column_one"}).
+						AddRow([]byte(`{"name":"Matt","active":true}`)),
+				)
+			},
+			nil,
+		},
+		{
+			"Should do query correctly and return correct values with single JSONB field and string return",
+			reflect.TypeOf(modelOneFieldJSONB{}),
+			nil,
+			[]interface{}{
+				modelOneFieldJSONB{
+					TestFieldOne: TestSerializedObject{
+						Name:               "Matt",
+						Active:             true,
+						NonSerializedField: "",
+					},
+				},
+			},
+			func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("^SELECT test_table.test_column_one FROM test_table$").WillReturnRows(
+					sqlmock.NewRows([]string{"test_column_one"}).
 						AddRow(`{"name":"Matt","active":true}`),
 				)
 			},
@@ -341,7 +363,7 @@ func TestDoFilterSelectWithJSONBField(t *testing.T) {
 				mock.ExpectBegin()
 				mock.ExpectQuery("^SELECT test_table.test_column_one FROM test_table$").WillReturnRows(
 					sqlmock.NewRows([]string{"test_column_one"}).
-						AddRow(`{"name":"Ben","active":true}`),
+						AddRow([]byte(`{"name":"Ben","active":true}`)),
 				)
 			},
 			nil,
@@ -370,7 +392,7 @@ func TestDoFilterSelectWithJSONBField(t *testing.T) {
 				mock.ExpectBegin()
 				mock.ExpectQuery("^SELECT test_table.test_column_one FROM test_table$").WillReturnRows(
 					sqlmock.NewRows([]string{"test_column_one"}).
-						AddRow(`[{"name":"Matt","active":true},{"name":"Ben","active":true}]`),
+						AddRow([]byte(`[{"name":"Matt","active":true},{"name":"Ben","active":true}]`)),
 				)
 			},
 			nil,


### PR DESCRIPTION
## Changelog
- Determine whether the return value from database is `string` or `[]byte` typed before hydrating into field.
- Fix tests to introduce cases for both string and byte slice returns from db