### PR TITLE
Fixes Validation so we're not double validating

### DIFF
--- a/picard.go
+++ b/picard.go
@@ -601,7 +601,7 @@ func (p PersistenceORM) generateChanges(
 			continue
 		}
 
-		dbChange, err := p.processObject(value, existingObj, foreignKeys)
+		dbChange, err := p.processObject(value, existingObj, foreignKeys, true)
 
 		if err != nil {
 			return nil, nil, nil, err
@@ -645,6 +645,7 @@ func (p PersistenceORM) processObject(
 	metadataObject reflect.Value,
 	databaseObject map[string]interface{},
 	foreignKeys []ForeignKey,
+	doValidation bool,
 ) (DBChange, error) {
 	returnObject := map[string]interface{}{}
 
@@ -739,8 +740,10 @@ func (p PersistenceORM) processObject(
 		}
 	}
 
-	if err := validator.New().Struct(metadataObject.Interface()); err != nil {
-		return DBChange{}, err
+	if doValidation {
+		if err := validator.New().Struct(metadataObject.Interface()); err != nil {
+			return DBChange{}, err
+		}
 	}
 
 	return DBChange{

--- a/save.go
+++ b/save.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	uuid "github.com/satori/go.uuid"
-	validator "gopkg.in/go-playground/validator.v9"
 )
 
 // SaveModel performs an upsert operation for the provided model.
@@ -78,12 +77,6 @@ func (p PersistenceORM) persistModel(model interface{}, alwaysInsert bool) error
 			persistColumns = append(persistColumns, primaryKeyColumnName)
 		}
 
-		// Only Validate on Inserts
-		if err := validator.New().Struct(model); err != nil {
-			tx.Rollback()
-			return err
-		}
-
 		if err := p.insertModel(modelValue, tableName, persistColumns, primaryKeyColumnName); err != nil {
 			tx.Rollback()
 			return err
@@ -108,7 +101,7 @@ func (p PersistenceORM) updateModel(modelValue reflect.Value, tableName string, 
 	if existingObject == nil {
 		return ModelNotFoundError
 	}
-	change, err := p.processObject(modelValue, existingObject, nil)
+	change, err := p.processObject(modelValue, existingObject, nil, false)
 	if err != nil {
 		return err
 	}
@@ -116,7 +109,7 @@ func (p PersistenceORM) updateModel(modelValue reflect.Value, tableName string, 
 }
 
 func (p PersistenceORM) insertModel(modelValue reflect.Value, tableName string, columnNames []string, primaryKeyColumnName string) error {
-	change, err := p.processObject(modelValue, nil, nil)
+	change, err := p.processObject(modelValue, nil, nil, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It turns out that all of the save functions end up calling the lower-level processObject function. So to get validation on deploys, and inserts, but not updates, I needed to add a flag to the processObject function.

Changelog:
1. Add Validation flag to processObject function.
2. Remove validation from insert code and rely on the lower level validation in processObject.
3. Validation is no longer happening twice for inserts.