### PR TITLE
Add Insert Batching

### DIFF
--- a/picard.go
+++ b/picard.go
@@ -211,19 +211,15 @@ func (p PersistenceORM) performInserts(inserts []DBChange, insertsHavePrimaryKey
 	insertCount := len(inserts)
 	if insertCount > 0 {
 		for i := 0; i < insertCount; i += insertBatchSize {
-			fmt.Println("Batch Start")
 			end := i + insertBatchSize
 			if end > insertCount {
 				end = insertCount
 			}
-			fmt.Println(i)
-			fmt.Println(end)
 			err := p.performInsertBatch(inserts[i:end], insertsHavePrimaryKey, tableMetadata)
 			if err != nil {
 				return err
 			}
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
Splits up inserts into batches of 100. This prevents us from hitting "max number of parameter" limits in postgres