### PR TITLE
Fixes Picard handling decoding of null values.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -112,8 +112,6 @@ func decodeMatching(rawMap map[string]json.RawMessage, reflectedValue reflect.Va
 			continue
 		}
 
-		addDefinedField(metadataField, field.Name)
-
 		temp := reflect.New(field.Type).Interface()
 
 		if field.Type.Kind() == reflect.Struct || field.Type.Kind() == reflect.Slice {
@@ -129,7 +127,10 @@ func decodeMatching(rawMap map[string]json.RawMessage, reflectedValue reflect.Va
 		}
 
 		actualValue := reflect.Indirect(reflect.ValueOf(temp))
-		reflectedValue.FieldByName(field.Name).Set(actualValue)
+		if actualValue.IsValid() {
+			addDefinedField(metadataField, field.Name)
+			reflectedValue.FieldByName(field.Name).Set(actualValue)
+		}
 
 	}
 	return nil

--- a/decode_test.go
+++ b/decode_test.go
@@ -33,6 +33,23 @@ func TestUnmarshal(t *testing.T) {
 			"",
 		},
 		{
+			"Unmarshal a testObject with a null value",
+			[]byte(`{
+				"id":"myID",
+				"name":null
+			}`),
+			&TestObject{},
+			&TestObject{
+				Metadata: Metadata{
+					DefinedFields: []string{"ID"},
+				},
+				ID:       "myID",
+				Name:     "",
+				Children: nil,
+			},
+			"",
+		},
+		{
 			"Unmarshal a testObject with a child object",
 			[]byte(`{
 				"id":"anotherID",


### PR DESCRIPTION
This allows picard to handle null values correctly. Previously, null values were causing a panic. For now I made the decision to treat null values as "Not Defined" and not add them to the list of defined fields. The other option would be to treat them as "Defined", but then they would not be distinguishable from an empty string inside of a Go Struct. Doesn't really make me happy either way.