### PR TITLE
Adds Key Map Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,6 @@ Indicates that this field represents a foreign key in another table.
 #### related
 Specifies the field also in this struct that contains the related data. The field specified here must be of kind struct.
 
+#### key_map
+Optional. Only valid for fields that are strings and are marked as a foreign key. This indicates that the value in this property should be mapped to the specified field of the related object.
+

--- a/tags.go
+++ b/tags.go
@@ -253,6 +253,7 @@ func tableMetadataFromType(t reflect.Type) *tableMetadata {
 					RelatedFieldName: relatedField.Name,
 					Required:         isRequired,
 					NeedsLookup:      isLookup,
+					KeyMapField:      tagsMap["key_map"],
 				})
 			}
 		}

--- a/testdata/ChildWithParentLookupAndKeyMap.json
+++ b/testdata/ChildWithParentLookupAndKeyMap.json
@@ -1,0 +1,4 @@
+{
+	"name": "ChildItem",
+	"parent": "Simple"
+}


### PR DESCRIPTION
This feature is for a hobby project I'm working on, but I think it's a pretty useful general purpose feature.

For example lets say we have two objects, Patient and Doctor, each patient only has one doctor.

Previously, to deploy a Patient and specify that patient's doctor, you'd need a payload like this...

patient.json
```
{
    name: "PatientName",
    doctor: {
        name: "DoctorName
    }
}
   
```

however, with the key_map struct tag, you can specify that the payload will not contain an entire doctor object, but just the doctor's unique key. That way a payload like this...
patient.json
```
{
    name: "PatientName",
    doctor: "DoctorName"
}
```

...will work just fine.

We're basically mapping the property in that field to a particular property in the parent object.