### PR TITLE
PLIN-1761 Temporary no joins on deletes

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -1,8 +1,6 @@
 package picard
 
 import (
-	"errors"
-
 	"github.com/Masterminds/squirrel"
 )
 
@@ -17,13 +15,9 @@ func (porm PersistenceORM) DeleteModel(model interface{}) (int64, error) {
 	tableMetadata := tableMetadataFromType(modelValue.Type())
 	tableName := tableMetadata.getTableName()
 
-	whereClauses, joinClauses, err := porm.generateWhereClausesFromModel(modelValue, nil, tableMetadata)
+	whereClauses, _, err := porm.generateWhereClausesFromModel(modelValue, nil, tableMetadata, false)
 	if err != nil {
 		return 0, err
-	}
-
-	if len(joinClauses) > 0 {
-		return 0, errors.New("Cannot filter on related data for deletes")
 	}
 
 	if porm.transaction == nil {

--- a/filter.go
+++ b/filter.go
@@ -11,7 +11,7 @@ import (
 
 func (p PersistenceORM) getFilterModelResults(filterModelValue reflect.Value, filterMetadata *tableMetadata) ([]interface{}, error) {
 	var zeroFields []string
-	whereClauses, joinClauses, err := p.generateWhereClausesFromModel(filterModelValue, zeroFields, filterMetadata)
+	whereClauses, joinClauses, err := p.generateWhereClausesFromModel(filterModelValue, zeroFields, filterMetadata, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes a bug where a joined table's fields were being added to the where clauses, without the join clause being present. We currently don't want to do joins on deletes so we should remove these fields from the where clause to prevent errors.

This gives us time to think about how we want to approach deletes for parents, etc, so we can remove this logic in the future.

https://skuidify.atlassian.net/browse/PLIN-1761