### PR TITLE
Improve orphan delete behavior and add tests

### DIFF
--- a/dbchange/dbchange.go
+++ b/dbchange/dbchange.go
@@ -1,0 +1,31 @@
+package dbchange
+
+import "reflect"
+
+// Type is an enum for the type of change being made. Insert, Update or Delete
+type Type int
+
+const (
+	// Insert Type
+	Insert Type = iota
+	// Update Type
+	Update
+	// Delete Type
+	Delete
+)
+
+// Change structure
+type Change struct {
+	Changes       map[string]interface{}
+	OriginalValue reflect.Value
+	Key           string
+	Type          Type
+}
+
+// ChangeSet structure
+type ChangeSet struct {
+	Inserts               []Change
+	Updates               []Change
+	Deletes               []Change
+	InsertsHavePrimaryKey bool
+}

--- a/save.go
+++ b/save.go
@@ -3,6 +3,8 @@ package picard
 import (
 	"errors"
 	"reflect"
+
+	"github.com/skuid/picard/dbchange"
 )
 
 // SaveModel performs an upsert operation for the provided model.
@@ -60,7 +62,7 @@ func (p PersistenceORM) updateModel(modelValue reflect.Value, tableMetadata *tab
 	if err != nil {
 		return err
 	}
-	return p.performUpdates([]DBChange{change}, tableMetadata)
+	return p.performUpdates([]dbchange.Change{change}, tableMetadata)
 }
 
 func (p PersistenceORM) insertModel(modelValue reflect.Value, tableMetadata *tableMetadata, primaryKeyValue interface{}) error {
@@ -69,17 +71,17 @@ func (p PersistenceORM) insertModel(modelValue reflect.Value, tableMetadata *tab
 		return err
 	}
 	insertsHavePrimaryKey := !(primaryKeyValue == nil || primaryKeyValue == "")
-	if err := p.performInserts([]DBChange{change}, insertsHavePrimaryKey, tableMetadata); err != nil {
+	if err := p.performInserts([]dbchange.Change{change}, insertsHavePrimaryKey, tableMetadata); err != nil {
 		return err
 	}
 	setPrimaryKeyFromInsertResult(modelValue, change, tableMetadata)
 	return nil
 }
 
-func setPrimaryKeyFromInsertResult(v reflect.Value, change DBChange, tableMetadata *tableMetadata) {
+func setPrimaryKeyFromInsertResult(v reflect.Value, change dbchange.Change, tableMetadata *tableMetadata) {
 	fieldName := tableMetadata.getPrimaryKeyFieldName()
 	columnName := tableMetadata.getPrimaryKeyColumnName()
 	if fieldName != "" {
-		v.FieldByName(fieldName).Set(reflect.ValueOf(change.changes[columnName]))
+		v.FieldByName(fieldName).Set(reflect.ValueOf(change.Changes[columnName]))
 	}
 }

--- a/save_test.go
+++ b/save_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/skuid/picard/dbchange"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -812,7 +813,7 @@ func TestSetPrimaryKeyFromInsertResult(t *testing.T) {
 	testCases := []struct {
 		description  string
 		giveValue    reflect.Value
-		giveDBChange DBChange
+		giveDBChange dbchange.Change
 		wantValue    reflect.Value
 	}{
 		{
@@ -820,8 +821,8 @@ func TestSetPrimaryKeyFromInsertResult(t *testing.T) {
 			reflect.Indirect(reflect.ValueOf(&struct {
 				PrimaryKeyField string `picard:"primary_key,column=primary_key_column"`
 			}{})),
-			DBChange{
-				changes: map[string]interface{}{
+			dbchange.Change{
+				Changes: map[string]interface{}{
 					"primary_key_column": "00000000-0000-0000-0000-000000000001",
 				},
 			},
@@ -836,8 +837,8 @@ func TestSetPrimaryKeyFromInsertResult(t *testing.T) {
 			reflect.Indirect(reflect.ValueOf(&struct {
 				PrimaryKeyField string `picard:"primary_key,column=another_pk_column"`
 			}{})),
-			DBChange{
-				changes: map[string]interface{}{
+			dbchange.Change{
+				Changes: map[string]interface{}{
 					"another_pk_column": "00000000-0000-0000-0000-000000000002",
 				},
 			},
@@ -852,8 +853,8 @@ func TestSetPrimaryKeyFromInsertResult(t *testing.T) {
 			reflect.Indirect(reflect.ValueOf(&struct {
 				PrimaryKeyField string `picard:"column=primary_key_column"`
 			}{})),
-			DBChange{
-				changes: map[string]interface{}{
+			dbchange.Change{
+				Changes: map[string]interface{}{
 					"primary_key_column": "00000000-0000-0000-0000-000000000001",
 				},
 			},

--- a/tags.go
+++ b/tags.go
@@ -32,7 +32,6 @@ type tableMetadata struct {
 	lookups              []Lookup
 	foreignKeys          []ForeignKey
 	children             []Child
-	deleteOrphans        bool
 }
 
 func (tm tableMetadata) getTableName() string {
@@ -217,15 +216,11 @@ func tableMetadataFromType(t reflect.Type) *tableMetadata {
 		_, isForeignKey := tagsMap["foreign_key"]
 		_, isEncrypted := tagsMap["encrypted"]
 		_, isJSONB := tagsMap["jsonb"]
-		_, deleteOrphans := tagsMap["delete_orphans"]
 		auditType, _ := tagsMap["audit"]
 
 		if field.Type == reflect.TypeOf(metadata) {
 			if hasTableName {
 				tableMetadata.tableName = tagsMap["tablename"]
-			}
-			if deleteOrphans {
-				tableMetadata.deleteOrphans = true
 			}
 		}
 
@@ -259,6 +254,7 @@ func tableMetadataFromType(t reflect.Type) *tableMetadata {
 			keyMappingString := tagsMap["key_mapping"]
 			valueMappingString := tagsMap["value_mappings"]
 			groupingCriteriaString := tagsMap["grouping_criteria"]
+			_, deleteOrphans := tagsMap["delete_orphans"]
 
 			if groupingCriteriaString != "" {
 				groupingCriteriaMap = map[string]string{}
@@ -290,6 +286,7 @@ func tableMetadataFromType(t reflect.Type) *tableMetadata {
 				KeyMapping:       keyMapping,
 				ValueMappings:    valueMappingMap,
 				GroupingCriteria: groupingCriteriaMap,
+				DeleteOrphans:    deleteOrphans,
 			})
 
 		}

--- a/testdata/SimpleWithChildrenAndChildrenMap.json
+++ b/testdata/SimpleWithChildrenAndChildrenMap.json
@@ -1,0 +1,13 @@
+{
+	"name": "SimpleWithChildren",
+	"type": "SimpleWithChildrenType",
+	"children": [
+		{
+			"name": "ChildRecord"
+		},
+		{
+			"name": "ChildRecord2"
+		}
+	 ],
+	 "childrenmap": {}
+ }


### PR DESCRIPTION
This PR does a couple things.
1. Split out our "DBChange" object into a separate package for cleanliness. Also adds a dbchange.Type enum for keeping track of the type of the dbchange.
2. Move the remove_orphans struct tag to the child relationship instead of the table metadata. This gives more control over which relationships we want to delete orphans for.
3. Only remove orphans if the struct for that child relationship is not nil. This means we'll remove orphans for empty structs, but not nil ones.
4. Only add items to the deleteFilter if they are updates, we don't need to remove orphans for inserts, because we are guaranteed that they don't have any children.
5. Add tests for these changes.