### PR TITLE
Allows multiple deployments to be made in the same transaction

### DIFF
--- a/picard.go
+++ b/picard.go
@@ -139,6 +139,7 @@ func (p PersistenceORM) DeployMultiple(data []interface{}) error {
 
 	for _, dataItem := range data {
 		if err = p.upsert(dataItem, nil); err != nil {
+			tx.Rollback()
 			return err
 		}
 	}


### PR DESCRIPTION
I want to do both the data source and permission deployment in Warden using the same transaction. This allows for that.