### PR TITLE
Fixes PLIN-1843 Use Default instead of null for undefined inserts

### DIFF
--- a/picard.go
+++ b/picard.go
@@ -1110,7 +1110,12 @@ func getLookupQueryResults(rows *sql.Rows, tableName string, lookups []Lookup, t
 func getColumnValues(columnNames []string, data map[string]interface{}) []interface{} {
 	columnValues := []interface{}{}
 	for _, columnName := range columnNames {
-		columnValues = append(columnValues, data[columnName])
+		columnValue, hasValue := data[columnName]
+		if hasValue {
+			columnValues = append(columnValues, columnValue)
+		} else {
+			columnValues = append(columnValues, squirrel.Expr("DEFAULT"))
+		}
 	}
 	return columnValues
 }

--- a/save_test.go
+++ b/save_test.go
@@ -174,8 +174,8 @@ func TestSaveModel(t *testing.T) {
 			},
 			func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectQuery(`^INSERT INTO test_tablename \(multitenancy_key_column,test_column_one\) VALUES \(\$1,\$2\) RETURNING "primary_key_column"$`).
-					WithArgs("00000000-0000-0000-0000-000000000005", nil).
+				mock.ExpectQuery(`^INSERT INTO test_tablename \(multitenancy_key_column,test_column_one\) VALUES \(\$1,DEFAULT\) RETURNING "primary_key_column"$`).
+					WithArgs("00000000-0000-0000-0000-000000000005").
 					WillReturnRows(
 						sqlmock.NewRows([]string{"primary_key_column"}).AddRow("00000000-0000-0000-0000-000000000001"),
 					)

--- a/testing.go
+++ b/testing.go
@@ -245,13 +245,20 @@ func ExpectInsert(mock *sqlmock.Sqlmock, expect ExpectationHelper, columnNames [
 
 	for _, insertValue := range insertValues {
 		valueParams := []string{}
+		nonNullInsertValues := []driver.Value{}
 
-		for range columnNames {
-			valueParams = append(valueParams, `\$`+strconv.Itoa(index))
-			index++
+		for columnIndex := range columnNames {
+			columnValue := insertValue[columnIndex]
+			if columnValue == nil {
+				valueParams = append(valueParams, `DEFAULT`)
+			} else {
+				valueParams = append(valueParams, `\$`+strconv.Itoa(index))
+				nonNullInsertValues = append(nonNullInsertValues, columnValue)
+				index++
+			}
 		}
 
-		expectedArgs = append(expectedArgs, insertValue...)
+		expectedArgs = append(expectedArgs, nonNullInsertValues...)
 		valueStrings = append(valueStrings, strings.Join(valueParams, ","))
 
 		returnData = append(returnData, []driver.Value{


### PR DESCRIPTION
This changes picard to use the DEFAULT keyword instead of putting in nulls for values that weren't defined on the object.