### PR TITLE
Fixes PLIN-1880 missing lookups on non-first-batch batches

### DIFF
--- a/picard.go
+++ b/picard.go
@@ -24,7 +24,6 @@ import (
 )
 
 const separator = "|"
-const batchSize = 100
 
 // Association structure
 type Association struct {
@@ -86,6 +85,7 @@ type PersistenceORM struct {
 	multitenancyValue string
 	performedBy       string
 	transaction       *sql.Tx
+	batchSize         int
 }
 
 // New Creates a new Picard Object and handle defaults
@@ -93,6 +93,7 @@ func New(multitenancyValue string, performerID string) ORM {
 	return PersistenceORM{
 		multitenancyValue: multitenancyValue,
 		performedBy:       performerID,
+		batchSize:         100,
 	}
 }
 
@@ -156,8 +157,8 @@ func (p PersistenceORM) upsert(data interface{}, deleteFilters interface{}) erro
 	dataValue := reflect.ValueOf(data)
 	dataCount := dataValue.Len()
 	if dataCount > 0 {
-		for i := 0; i < dataCount; i += batchSize {
-			end := i + batchSize
+		for i := 0; i < dataCount; i += p.batchSize {
+			end := i + p.batchSize
 			if end > dataCount {
 				end = dataCount
 			}

--- a/testing.go
+++ b/testing.go
@@ -318,7 +318,7 @@ func ExpectUpdate(mock *sqlmock.Sqlmock, expect ExpectationHelper, updateColumnN
 }
 
 // RunImportTest Runs a Test Object Import Test
-func RunImportTest(testObjects interface{}, testFunction func(*sqlmock.Sqlmock, interface{})) error {
+func RunImportTest(testObjects interface{}, testFunction func(*sqlmock.Sqlmock, interface{}), batchSize int) error {
 	// Open new mock database
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -334,7 +334,10 @@ func RunImportTest(testObjects interface{}, testFunction func(*sqlmock.Sqlmock, 
 	mock.ExpectBegin()
 	testFunction(&mock, testObjects)
 	mock.ExpectCommit()
+
+	p := New(orgID, userID).(PersistenceORM)
+	p.batchSize = batchSize
 	// Deploy the list of data sources
-	return New(orgID, userID).Deploy(testObjects)
+	return p.Deploy(testObjects)
 
 }


### PR DESCRIPTION
Previously, we were mutating the NeedsLookup property on the foreign key metadata. Then we were using that same metadata on subsequent batches. This was causing subsequent batches to be queried with missing foreign key lookups. This PR stops mutating the NeedsLookup property as well as optimizes some of the lookup generation code.