### PR TITLE
NO-TICKET: index out of bounds fix

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -249,7 +249,10 @@ func ExpectInsert(mock *sqlmock.Sqlmock, expect ExpectationHelper, columnNames [
 		nonNullInsertValues := []driver.Value{}
 
 		for columnIndex := range columnNames {
-			columnValue := insertValue[columnIndex]
+			var columnValue interface{}
+			if columnIndex >= 0 && columnIndex < len(insertValue) {
+				columnValue = insertValue[columnIndex]
+			}
 			if columnValue == nil {
 				valueParams = append(valueParams, `DEFAULT`)
 			} else {


### PR DESCRIPTION
I was getting a failure in the warden tests that was throwing a panic. This should keep that from happening.