### PR TITLE
Cleans up the Filtering API, Also Adds Ordering Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ func doLookup() {
 		Name: "foo"
 	}
 
-	results, err := picardORM.FilterModel(filterModel)
+	results, err := picardORM.FilterModel(picard.FilterRequest{
+		FilterModel: filterModel,
+	})
 	// test err and results array for length
 	tbl := results[0].(tableA)
 }
@@ -65,7 +67,10 @@ func doEagerLoadLookUp() {
 		Name: "foo"
 	}
 	// association 'allthebs.allthecs'
-	results, err := picardORM.FilterModelAssociations(filterModel, []string{"AllTheBs.AllTheCs"}))
+	results, err := picardORM.FilterModel(picard.FilterRequest{
+		FilterModel: filterModel, 
+		Associations: []string{"AllTheBs.AllTheCs"}),
+	})
 }
 ```
 

--- a/delete.go
+++ b/delete.go
@@ -31,7 +31,10 @@ func (porm PersistenceORM) DeleteModel(model interface{}) (int64, error) {
 	lookupPks := make([]interface{}, 0)
 	if len(associations) > 0 {
 		_, pk := reflectutil.ReflectTableInfo(reflect.TypeOf(model))
-		results, err := porm.FilterModelAssociations(model, associations)
+		results, err := porm.FilterModel(FilterRequest{
+			FilterModel:  model,
+			Associations: associations,
+		})
 		if err != nil {
 			return 0, err
 		}

--- a/examples/users/users.go
+++ b/examples/users/users.go
@@ -69,12 +69,15 @@ func doLookup(p picard.ORM) ([]interface{}, error) {
 	filter := User{
 		Name: "JohnDoe",
 	}
-	results, err := p.FilterModelAssociations(filter, []tags.Association{
-		{
-			Name: "post",
-			Associations: []tags.Association{
-				{
-					Name: "tag",
+	results, err := p.FilterModel(picard.FilterRequest{
+		FilterModel: filter,
+		Associations: []tags.Association{
+			{
+				Name: "post",
+				Associations: []tags.Association{
+					{
+						Name: "tag",
+					},
 				},
 			},
 		},

--- a/picard.go
+++ b/picard.go
@@ -29,8 +29,7 @@ const separator = "|"
 
 // ORM interface describes the behavior API of any picard ORM
 type ORM interface {
-	FilterModel(interface{}) ([]interface{}, error)
-	FilterModelAssociations(interface{}, []tags.Association) ([]interface{}, error)
+	FilterModel(FilterRequest) ([]interface{}, error)
 	SaveModel(model interface{}) error
 	CreateModel(model interface{}) error
 	DeleteModel(model interface{}) (int64, error)
@@ -144,7 +143,10 @@ func (p PersistenceORM) upsert(data interface{}, deleteFilters interface{}) erro
 
 	if deleteFilters != nil {
 		deletes := []dbchange.Change{}
-		deleteResults, err := p.FilterModels(deleteFilters, p.transaction)
+		deleteResults, err := p.FilterModel(FilterRequest{
+			FilterModel: deleteFilters,
+			Runner:      p.transaction,
+		})
 		if err != nil {
 			return err
 		}

--- a/picard_test/mock.go
+++ b/picard_test/mock.go
@@ -3,46 +3,34 @@ package picard_test
 import (
 	"errors"
 
-	"github.com/skuid/picard/tags"
+	"github.com/skuid/picard"
 )
 
 // MockORM can be used to test client functionality that calls picard.ORM behavior.
 type MockORM struct {
-	FilterModelReturns                []interface{}
-	FilterModelError                  error
-	FilterModelCalledWith             interface{}
-	FilterModelAssociationsReturns    []interface{}
-	FilterModelAssociationsError      error
-	FilterModelAssociationsCalledWith interface{}
-	SaveModelError                    error
-	SaveModelCalledWith               interface{}
-	CreateModelError                  error
-	CreateModelCalledWith             interface{}
-	DeployError                       error
-	DeployCalledWith                  interface{}
-	DeployMultipleError               error
-	DeployMultipleCalledWith          []interface{}
-	DeleteModelRowsAffected           int64
-	DeleteModelError                  error
-	DeleteModelCalledWith             interface{}
+	FilterModelReturns       []interface{}
+	FilterModelError         error
+	FilterModelCalledWith    picard.FilterRequest
+	SaveModelError           error
+	SaveModelCalledWith      interface{}
+	CreateModelError         error
+	CreateModelCalledWith    interface{}
+	DeployError              error
+	DeployCalledWith         interface{}
+	DeployMultipleError      error
+	DeployMultipleCalledWith []interface{}
+	DeleteModelRowsAffected  int64
+	DeleteModelError         error
+	DeleteModelCalledWith    interface{}
 }
 
 // FilterModel simply returns an error or return objects when set on the MockORM
-func (morm *MockORM) FilterModel(filterModel interface{}) ([]interface{}, error) {
-	morm.FilterModelCalledWith = filterModel
+func (morm *MockORM) FilterModel(request picard.FilterRequest) ([]interface{}, error) {
+	morm.FilterModelCalledWith = request
 	if morm.FilterModelError != nil {
 		return nil, morm.FilterModelError
 	}
 	return morm.FilterModelReturns, nil
-}
-
-// FilterModelAssociations simply returns an error or return objects when set on the MockORM
-func (morm *MockORM) FilterModelAssociations(filterModel interface{}, associations []tags.Association) ([]interface{}, error) {
-	morm.FilterModelAssociationsCalledWith = filterModel
-	if morm.FilterModelAssociationsError != nil {
-		return nil, morm.FilterModelAssociationsError
-	}
-	return morm.FilterModelAssociationsReturns, nil
 }
 
 // SaveModel returns the error stored in MockORM, and records the call value
@@ -92,21 +80,12 @@ func (multi *MultiMockORM) next() (*MockORM, error) {
 }
 
 // FilterModel simply returns an error or return objects when set on the MockORM
-func (multi *MultiMockORM) FilterModel(filterModel interface{}) ([]interface{}, error) {
+func (multi *MultiMockORM) FilterModel(request picard.FilterRequest) ([]interface{}, error) {
 	next, err := multi.next()
 	if err != nil {
 		return nil, err
 	}
-	return next.FilterModel(filterModel)
-}
-
-// FilterModelAssociations simply returns an error or return objects when set on the MockORM
-func (multi *MultiMockORM) FilterModelAssociations(filterModel interface{}, associations []tags.Association) ([]interface{}, error) {
-	next, err := multi.next()
-	if err != nil {
-		return nil, err
-	}
-	return next.FilterModelAssociations(filterModel, associations)
+	return next.FilterModel(request)
 }
 
 // SaveModel returns the error stored in MockORM, and records the call value

--- a/picard_test/mock_test.go
+++ b/picard_test/mock_test.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/skuid/picard"
 	"github.com/skuid/picard/picard_test"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMockFilterModelAssociations(t *testing.T) {
+func TestMockFilterModel(t *testing.T) {
 	testCases := []struct {
 		description     string
 		giveFilterModel interface{}
@@ -51,7 +52,9 @@ func TestMockFilterModelAssociations(t *testing.T) {
 				FilterModelError:   tc.giveError,
 			}
 
-			results, err := morm.FilterModel(tc.giveFilterModel)
+			results, err := morm.FilterModel(picard.FilterRequest{
+				FilterModel: tc.giveFilterModel,
+			})
 
 			if tc.giveError != nil {
 				assert.Error(t, err)
@@ -59,7 +62,9 @@ func TestMockFilterModelAssociations(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.giveReturns, results)
-				assert.Equal(t, tc.giveFilterModel, morm.FilterModelCalledWith)
+				assert.Equal(t, picard.FilterRequest{
+					FilterModel: tc.giveFilterModel,
+				}, morm.FilterModelCalledWith)
 			}
 		})
 	}
@@ -221,12 +226,12 @@ func TestMultiMockFilter(t *testing.T) {
 					{
 						FilterModelReturns:    []interface{}{},
 						FilterModelError:      nil,
-						FilterModelCalledWith: nil,
+						FilterModelCalledWith: picard.FilterRequest{},
 					},
 					{
 						FilterModelReturns:    nil,
 						FilterModelError:      errors.New("An Error Here"),
-						FilterModelCalledWith: nil,
+						FilterModelCalledWith: picard.FilterRequest{},
 					},
 				},
 			},
@@ -238,14 +243,22 @@ func TestMultiMockFilter(t *testing.T) {
 					Name: "Object2",
 				}
 
-				result1, err := mmorm.FilterModel(callWith1)
+				result1, err := mmorm.FilterModel(picard.FilterRequest{
+					FilterModel: callWith1,
+				})
 				assert.Equal(t, result1, mmorm.MockORMs[0].FilterModelReturns)
 				assert.Equal(t, err, mmorm.MockORMs[0].FilterModelError)
-				assert.Equal(t, callWith1, mmorm.MockORMs[0].FilterModelCalledWith)
-				result2, err := mmorm.FilterModel(callWith2)
+				assert.Equal(t, picard.FilterRequest{
+					FilterModel: callWith1,
+				}, mmorm.MockORMs[0].FilterModelCalledWith)
+				result2, err := mmorm.FilterModel(picard.FilterRequest{
+					FilterModel: callWith2,
+				})
 				assert.Equal(t, result2, mmorm.MockORMs[1].FilterModelReturns)
 				assert.Equal(t, err, mmorm.MockORMs[1].FilterModelError)
-				assert.Equal(t, callWith2, mmorm.MockORMs[1].FilterModelCalledWith)
+				assert.Equal(t, picard.FilterRequest{
+					FilterModel: callWith2,
+				}, mmorm.MockORMs[1].FilterModelCalledWith)
 			},
 		},
 		{
@@ -255,7 +268,9 @@ func TestMultiMockFilter(t *testing.T) {
 				callWith := simpleObject{
 					Name: "Object1",
 				}
-				result, err := mmorm.FilterModel(callWith)
+				result, err := mmorm.FilterModel(picard.FilterRequest{
+					FilterModel: callWith,
+				})
 				var expectedResult []interface{}
 				assert.Equal(t, result, expectedResult)
 				assert.Equal(t, err, errors.New("Mock Function was called but not expected"))

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -201,5 +201,5 @@ func FmtSQLRegex(sql string) string {
 	str = strings.Replace(str, "$", "\\$", -1)
 	str = strings.Replace(str, "(", "\\(", -1)
 	str = strings.Replace(str, ")", "\\)", -1)
-	return fmt.Sprintf("^%s", str)
+	return fmt.Sprintf("^%s$", str)
 }


### PR DESCRIPTION
1. Change the signature of picard.FilterModel to accept a "FilterRequest" struct. This will allow us to expand the functionality of picard without adding new functions for every feature.

2. Remove picard.FilterModelAssociations as it's covered in picard.FilterModel now.

3. Remove picard.FilterModels as it's covered in picard.FilterModel now.

4. Add the ability to specify fields to order by in a FilterModel request.
