### PR TITLE
PLIN-2582

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+REPO=picard
+TAG ?= latest
+BUILD_TAG ?= latest
+SHA = $(shell git rev-parse --short HEAD)
+REV = $(shell git rev-list --tags --max-count=1)
+VERSION = $(shell git describe --tags $(REV))
+WD = $(shell basename $(dir $(abspath $(dir $$PWD))))
+
+
+test:
+	# @make service
+	@go test -cover ./...
+	
+testv:
+	@go test -v -cover ./...
+	
+build:
+	@go build -o picard

--- a/filter.go
+++ b/filter.go
@@ -139,8 +139,9 @@ func (p PersistenceORM) getSingleFilterResults(request FilterRequest, filterMeta
 	if err != nil {
 		return nil, err
 	}
+	tblAlias := tbl.Alias
 	aliasMap := tbl.FieldAliases()
-	return query.Hydrate(filterModel, aliasMap, rows, filterMetadata)
+	return query.Hydrate(filterModel, tblAlias, aliasMap, rows, filterMetadata)
 }
 
 func (p PersistenceORM) getMultiFilterResults(request FilterRequest, filterMetadata *tags.TableMetadata) ([]*reflect.Value, error) {
@@ -196,8 +197,9 @@ func (p PersistenceORM) getMultiFilterResults(request FilterRequest, filterMetad
 	if err != nil {
 		return nil, err
 	}
+	tblAlias := tbl.Alias
 	aliasMap := tbl.FieldAliases()
-	return query.Hydrate(filterModel, aliasMap, rows, filterMetadata)
+	return query.Hydrate(filterModel, tblAlias, aliasMap, rows, filterMetadata)
 }
 
 func (p PersistenceORM) getFilterResults(request FilterRequest, filterMetadata *tags.TableMetadata) ([]*reflect.Value, error) {

--- a/query/build.go
+++ b/query/build.go
@@ -23,9 +23,9 @@ func Build(multitenancyVal, model interface{}, filters tags.Filterable, associat
 
 	typ := val.Type()
 
-	stringutil.ResetAliasCounter()
+	counter := 0
 
-	tbl, err := buildQuery(multitenancyVal, typ, &val, filters, associations, selectFields, false, "", filterMetadata)
+	tbl, err := buildQuery(multitenancyVal, typ, &val, filters, associations, selectFields, false, "", filterMetadata, &counter)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +76,14 @@ func buildQuery(
 	onlyJoin bool,
 	refPath string,
 	filterMetadata *tags.TableMetadata,
+	counter *int,
 ) (*qp.Table, error) {
 	// Inspect current reflected value, and add select/where clauses
 
 	pkName := filterMetadata.GetPrimaryKeyColumnName()
 	tableName := filterMetadata.GetTableName()
 
-	tbl := NewAliased(tableName, stringutil.GenerateTableAlias(), refPath)
+	tbl := NewAliased(tableName, stringutil.GenerateTableAlias(counter), refPath)
 
 	cols := make([]string, 0, modelType.NumField())
 	seen := make(map[string]bool)
@@ -146,7 +147,7 @@ func buildQuery(
 					fkRefPath = refPath + "." + fieldName
 				}
 
-				refTbl, err := buildQuery(multitenancyVal, refTyp, &relatedVal, association.FieldFilters, association.Associations, association.SelectFields, childOnlyJoin, fkRefPath, refMetadata)
+				refTbl, err := buildQuery(multitenancyVal, refTyp, &relatedVal, association.FieldFilters, association.Associations, association.SelectFields, childOnlyJoin, fkRefPath, refMetadata, counter)
 				if err != nil {
 					return nil, err
 				}

--- a/query/build.go
+++ b/query/build.go
@@ -23,7 +23,9 @@ func Build(multitenancyVal, model interface{}, filters tags.Filterable, associat
 
 	typ := val.Type()
 
-	tbl, err := buildQuery(multitenancyVal, typ, &val, filters, associations, selectFields, false, 0, "", filterMetadata)
+	stringutil.ResetAliasCounter()
+
+	tbl, err := buildQuery(multitenancyVal, typ, &val, filters, associations, selectFields, false, "", filterMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +74,6 @@ func buildQuery(
 	associations []tags.Association,
 	selectFields []string,
 	onlyJoin bool,
-	counter int,
 	refPath string,
 	filterMetadata *tags.TableMetadata,
 ) (*qp.Table, error) {
@@ -81,7 +82,7 @@ func buildQuery(
 	pkName := filterMetadata.GetPrimaryKeyColumnName()
 	tableName := filterMetadata.GetTableName()
 
-	tbl := NewIndexed(tableName, counter, refPath)
+	tbl := NewAliased(tableName, stringutil.GenerateTableAlias(), refPath)
 
 	cols := make([]string, 0, modelType.NumField())
 	seen := make(map[string]bool)
@@ -145,9 +146,7 @@ func buildQuery(
 					fkRefPath = refPath + "." + fieldName
 				}
 
-				counter = counter + 1
-
-				refTbl, err := buildQuery(multitenancyVal, refTyp, &relatedVal, association.FieldFilters, association.Associations, association.SelectFields, childOnlyJoin, counter, fkRefPath, refMetadata)
+				refTbl, err := buildQuery(multitenancyVal, refTyp, &relatedVal, association.FieldFilters, association.Associations, association.SelectFields, childOnlyJoin, fkRefPath, refMetadata)
 				if err != nil {
 					return nil, err
 				}

--- a/query/hydrate.go
+++ b/query/hydrate.go
@@ -18,7 +18,7 @@ import (
 Hydrate takes the rows and pops them into the correct struct, in the correct
 order. This is usually called after you've built and executed the query model.
 */
-func Hydrate(filterModel interface{}, aliasMap map[string]qp.FieldDescriptor, rows *sql.Rows, meta *tags.TableMetadata) ([]*reflect.Value, error) {
+func Hydrate(filterModel interface{}, tblAlias string, aliasMap map[string]qp.FieldDescriptor, rows *sql.Rows, meta *tags.TableMetadata) ([]*reflect.Value, error) {
 	modelVal, err := stringutil.GetStructValue(filterModel)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func Hydrate(filterModel interface{}, aliasMap map[string]qp.FieldDescriptor, ro
 	}
 
 	hydrateds := make([]*reflect.Value, 0, len(mappedCols))
-	alias := fmt.Sprintf(qp.AliasedField, "t0", meta.GetTableName())
+	alias := fmt.Sprintf(qp.AliasedField, tblAlias, meta.GetTableName())
 	for _, mapped := range mappedCols {
 		hydrated, err := hydrate(typ, mapped, alias, aliasMap, "", meta)
 

--- a/query/hydrate_test.go
+++ b/query/hydrate_test.go
@@ -24,6 +24,7 @@ func TestHydrate(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		model    interface{}
+		tblAlias string
 		aliasMap map[string]qp.FieldDescriptor
 		rows     *sqlmock.Rows
 		expected []interface{}
@@ -33,6 +34,7 @@ func TestHydrate(t *testing.T) {
 			field{
 				Name: "pops",
 			},
+			"t0",
 			map[string]qp.FieldDescriptor{
 				"t0.id": qp.FieldDescriptor{
 					Alias:  "t0",
@@ -73,6 +75,7 @@ func TestHydrate(t *testing.T) {
 			field{
 				Name: "pops",
 			},
+			"t0",
 			map[string]qp.FieldDescriptor{
 				"t0.id": {
 					Alias:  "t0",
@@ -122,6 +125,7 @@ func TestHydrate(t *testing.T) {
 			field{
 				Name: "pops",
 			},
+			"t0",
 			map[string]qp.FieldDescriptor{
 				"t0.id": {
 					Alias:  "t0",
@@ -170,6 +174,7 @@ func TestHydrate(t *testing.T) {
 			field{
 				Name: "a_field",
 			},
+			"t0",
 			map[string]qp.FieldDescriptor{
 				"t0.id": qp.FieldDescriptor{
 					Alias:  "t0",
@@ -348,7 +353,7 @@ func TestHydrate(t *testing.T) {
 			}
 
 			// Testing our Hydrate function
-			actuals, err := Hydrate(tc.model, tc.aliasMap, rows, metadata)
+			actuals, err := Hydrate(tc.model, tc.tblAlias, tc.aliasMap, rows, metadata)
 			assert.NoError(err)
 			for i, actual := range actuals {
 				assert.Equal(tc.expected[i], actual.Interface().(field))

--- a/query/query.go
+++ b/query/query.go
@@ -11,7 +11,8 @@ import (
 
 // New returns a new table with a generated alias and the given name
 func New(name string) *qp.Table {
-	return qp.NewAliased(name, stringutil.GenerateNewTableAlias(), "")
+	index := 0
+	return qp.NewAliased(name, stringutil.GenerateNewTableAlias(&index), "")
 }
 
 // NewAliases returns a new table with the given alias

--- a/query/query.go
+++ b/query/query.go
@@ -6,18 +6,15 @@ package query
 
 import (
 	qp "github.com/skuid/picard/queryparts"
+	"github.com/skuid/picard/stringutil"
 )
 
-/*
-New returns a new table.
-*/
+// New returns a new table with a generated alias and the given name
 func New(name string) *qp.Table {
-	return qp.NewIndexed(name, 0, "")
+	return qp.NewAliased(name, stringutil.GenerateNewTableAlias(), "")
 }
 
-/*
-NewIndexed returns a new table.
-*/
-func NewIndexed(name string, index int, refPath string) *qp.Table {
-	return qp.NewIndexed(name, index, refPath)
+// NewAliases returns a new table with the given alias
+func NewAliased(name, alias, refPath string) *qp.Table {
+	return qp.NewAliased(name, alias, refPath)
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -437,6 +437,7 @@ func TestQueryJoins(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			counter := 1
 			assert := assert.New(t)
 
 			tbl := New("foo")
@@ -447,7 +448,7 @@ func TestQueryJoins(t *testing.T) {
 			}
 
 			for _, jt := range tc.joins {
-				appendTestJoin(tbl, jt)
+				appendTestJoin(tbl, jt, &counter)
 			}
 
 			for _, where := range tc.wheres {
@@ -469,8 +470,8 @@ func TestQueryJoins(t *testing.T) {
 	}
 }
 
-func appendTestJoin(tbl *qp.Table, jt joinTest) {
-	joinTbl := tbl.AppendJoin(jt.tbl, jt.joinField, jt.parentField, jt.jType)
+func appendTestJoin(tbl *qp.Table, jt joinTest, counter *int) {
+	joinTbl := tbl.AppendJoin(jt.tbl, jt.joinField, jt.parentField, jt.jType, counter)
 	if jt.joinMt != (whereTest{}) {
 		joinTbl.AddMultitenancyWhere(jt.joinMt.field, jt.joinMt.val)
 	}
@@ -480,7 +481,7 @@ func appendTestJoin(tbl *qp.Table, jt joinTest) {
 	}
 
 	for _, subJt := range jt.joins {
-		appendTestJoin(joinTbl, subJt)
+		appendTestJoin(joinTbl, subJt, counter)
 	}
 
 }
@@ -601,7 +602,8 @@ func TestFieldAliases(t *testing.T) {
 			tbl := New(tc.fixture.table)
 			tbl.AddColumns(tc.fixture.cols)
 
-			appendTestAliasJoin(tbl, tc.fixture.joins)
+			counter := 1
+			appendTestAliasJoin(tbl, tc.fixture.joins, &counter)
 			actual := tbl.FieldAliases()
 
 			assert.Equal(tc.expected, actual, "Expected the resulting SQL to match expected")
@@ -609,10 +611,10 @@ func TestFieldAliases(t *testing.T) {
 	}
 }
 
-func appendTestAliasJoin(tbl *qp.Table, joins []fieldAliasFixture) {
+func appendTestAliasJoin(tbl *qp.Table, joins []fieldAliasFixture, counter *int) {
 	for _, join := range joins {
-		joinTbl := tbl.AppendJoin(join.table, "foo", "bar", "")
+		joinTbl := tbl.AppendJoin(join.table, "foo", "bar", "", counter)
 		joinTbl.AddColumns(join.cols)
-		appendTestAliasJoin(tbl, join.joins)
+		appendTestAliasJoin(tbl, join.joins, counter)
 	}
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -180,7 +180,40 @@ func TestQueryJoins(t *testing.T) {
 		wheres       []whereTest
 		expected     string
 		expectedArgs []interface{}
-	}{
+	}{{
+		"should create the proper SQL for a simple table select with columns and two joins",
+		[]string{
+
+			"col_one",
+			"col_two",
+			"col_three",
+		},
+		[]joinTest{
+			{
+				tbl:         "table_b",
+				joinField:   "my_id",
+				parentField: "col_two",
+				jType:       "",
+			},
+			{
+				tbl:         "table_b",
+				joinField:   "my_id",
+				parentField: "col_two",
+				jType:       "",
+			},
+		},
+		whereTest{},
+		nil,
+		testdata.FmtSQL(`
+			SELECT t0.col_one AS "t0.col_one",
+				t0.col_two AS "t0.col_two",
+				t0.col_three AS "t0.col_three"
+			FROM foo AS t0
+			JOIN table_b AS t1 ON t1.my_id = t0.col_two
+			JOIN table_b AS t2 ON t2.my_id = t0.col_two
+		`),
+		nil,
+	},
 		{
 			"should create the proper SQL for a simple table select with columns and one join",
 			[]string{

--- a/queryparts/table.go
+++ b/queryparts/table.go
@@ -33,7 +33,8 @@ type Table struct {
 New returns a new table.
 */
 func New(name string) *Table {
-	return NewAliased(name, stringutil.GenerateTableAlias(), "")
+	index := 0
+	return NewAliased(name, stringutil.GenerateTableAlias(&index), "")
 }
 
 // NewAliased returns a new table with the given alias
@@ -81,7 +82,7 @@ func (t *Table) AddMultitenancyWhere(column string, val interface{}) {
 AppendJoin adds a join with the proper aliasing, including any columns requested
 from that table
 */
-func (t *Table) AppendJoin(tbl, joinField, parentField, jType string) *Table {
+func (t *Table) AppendJoin(tbl, joinField, parentField, jType string, counter *int) *Table {
 	var root *Table
 	if t.root != nil {
 		root = t.root
@@ -89,7 +90,7 @@ func (t *Table) AppendJoin(tbl, joinField, parentField, jType string) *Table {
 		root = t
 	}
 
-	alias := stringutil.GenerateTableAlias()
+	alias := stringutil.GenerateTableAlias(counter)
 
 	join := Join{
 		Table: &Table{

--- a/queryparts/table.go
+++ b/queryparts/table.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	sql "github.com/Masterminds/squirrel"
+	"github.com/skuid/picard/stringutil"
 )
 
 const (
@@ -18,7 +19,6 @@ a query by calling
 */
 type Table struct {
 	root         *Table
-	Counter      int
 	Alias        string
 	RefPath      string
 	Name         string
@@ -33,16 +33,13 @@ type Table struct {
 New returns a new table.
 */
 func New(name string) *Table {
-	return NewIndexed(name, 0, "")
+	return NewAliased(name, stringutil.GenerateTableAlias(), "")
 }
 
-/*
-NewIndexed returns a new table.
-*/
-func NewIndexed(name string, index int, refPath string) *Table {
+// NewAliased returns a new table with the given alias
+func NewAliased(name string, alias string, refPath string) *Table {
 	return &Table{
-		Counter: index + 1,
-		Alias:   fmt.Sprintf("t%d", index),
+		Alias:   alias,
 		RefPath: refPath,
 		Name:    name,
 		columns: make([]string, 0),
@@ -92,8 +89,7 @@ func (t *Table) AppendJoin(tbl, joinField, parentField, jType string) *Table {
 		root = t
 	}
 
-	alias := fmt.Sprintf("t%d", root.Counter)
-	root.Counter++
+	alias := stringutil.GenerateTableAlias()
 
 	join := Join{
 		Table: &Table{
@@ -117,17 +113,6 @@ AppendJoinTable adds a join with the proper aliasing, including any columns requ
 from that table
 */
 func (t *Table) AppendJoinTable(tbl *Table, joinField, parentField, jType string) *Table {
-	var root *Table
-	if t.root != nil {
-		root = t.root
-	} else {
-		root = t
-	}
-
-	// alias := fmt.Sprintf("t%d", root.Counter)
-	// tbl.Alias = alias
-	root.Counter++
-
 	join := Join{
 		Table:       tbl,
 		Parent:      t,

--- a/stringutil/strings.go
+++ b/stringutil/strings.go
@@ -5,6 +5,7 @@ package stringutil
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -50,4 +51,33 @@ func GetFilterType(v interface{}) (reflect.Type, error) {
 		return value.Type().Elem(), nil
 	}
 	return nil, errors.New("Filter must be struct or slice of structs")
+}
+
+// Table alias counter used to increment table aliases as we
+// progress through a query / join, etc.
+var (
+	tableAliasIndex = 0
+)
+
+// ResetAliasCounter is used when we're starting a new query. This ensures we
+// start with t0 & don't break any tests.
+func ResetAliasCounter() {
+	tableAliasIndex = 0
+}
+
+// GenerateTableAlias generates a table alias for queries, joins, etc
+// in the format of `t0`, `t1`, etc. This is to conform with existing tests
+// as well as maintain state across recursive functions.
+func GenerateTableAlias() (alias string) {
+	alias = fmt.Sprintf("t%v", tableAliasIndex)
+	tableAliasIndex += 1
+	return
+}
+
+// GenerateNewTableAlias is used to signify that we're starting a new
+// query and also need to reset the alias counter to t0
+func GenerateNewTableAlias() (alias string) {
+	ResetAliasCounter()
+	alias = GenerateTableAlias()
+	return
 }

--- a/stringutil/strings.go
+++ b/stringutil/strings.go
@@ -53,31 +53,19 @@ func GetFilterType(v interface{}) (reflect.Type, error) {
 	return nil, errors.New("Filter must be struct or slice of structs")
 }
 
-// Table alias counter used to increment table aliases as we
-// progress through a query / join, etc.
-var (
-	tableAliasIndex = 0
-)
-
-// ResetAliasCounter is used when we're starting a new query. This ensures we
-// start with t0 & don't break any tests.
-func ResetAliasCounter() {
-	tableAliasIndex = 0
-}
-
 // GenerateTableAlias generates a table alias for queries, joins, etc
 // in the format of `t0`, `t1`, etc. This is to conform with existing tests
 // as well as maintain state across recursive functions.
-func GenerateTableAlias() (alias string) {
-	alias = fmt.Sprintf("t%v", tableAliasIndex)
-	tableAliasIndex += 1
+func GenerateTableAlias(index *int) (alias string) {
+	alias = fmt.Sprintf("t%v", *index)
+	*index += 1
 	return
 }
 
 // GenerateNewTableAlias is used to signify that we're starting a new
 // query and also need to reset the alias counter to t0
-func GenerateNewTableAlias() (alias string) {
-	ResetAliasCounter()
-	alias = GenerateTableAlias()
+func GenerateNewTableAlias(index *int) (alias string) {
+	*index = 0
+	alias = GenerateTableAlias(index)
 	return
 }


### PR DESCRIPTION
# Issue Link

# High-Level Description

# Changelog:

- Refactored hard-coded `"t0"` reference to use package-level variable when forming queries
- Made sure refactored logic did not break tests
- Passed table alias as reference to query / join formations to avoid counter logic mismatch