### PR TITLE
PLIN-3287: basic handling for pointers

### DIFF
--- a/picard.go
+++ b/picard.go
@@ -903,6 +903,12 @@ func serializeJSONBColumn(value interface{}) (interface{}, error) {
 	if value == nil || value == "" {
 		return value, nil
 	}
+
+	// If the value is a pointer to a pointer to null, this prevents json serialization from go nil to json "null"
+	if (reflect.ValueOf(value).Kind() == reflect.Ptr) && (reflect.ValueOf(value).IsNil()) {
+		return nil, nil
+	}
+
 	return json.Marshal(value)
 }
 

--- a/query/hydrate.go
+++ b/query/hydrate.go
@@ -145,6 +145,25 @@ func setFieldValue(model *reflect.Value, field tags.FieldMetadata, value interfa
 			reflectedValue = reflectedValue.Convert(field.GetFieldType())
 			value = reflectedValue.Interface()
 			model.FieldByName(field.GetName()).Set(reflect.ValueOf(value))
+		} else if field.GetFieldType().Kind() == reflect.Ptr {
+			switch field.GetFieldType().Elem().Kind() {
+			case reflect.Float64:
+				if f, ok := value.(float64); ok {
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&f))
+				}
+			case reflect.Int:
+				if i, ok := value.(int); ok {
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&i))
+				}
+			case reflect.String:
+				if s, ok := value.(string); ok {
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&s))
+				}
+			case reflect.Bool:
+				if b, ok := value.(bool); ok {
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&b))
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
# Issue Link
https://skuidify.atlassian.net/browse/PLIN-3287

# High-Level Description
This PR updates picard's serialization of json blobs. Before, if the value was a pointer to a pointer to null, the null would be populated as the literal string value "null". Now, it populates the value with the proper postgresql null.

Additionally, it updates the hydration for field properties that are pointers. This allows warden to serialize and deserialize fields as null, and then differentiate what properties were actually provided in an update request.

# Changelog:
- `picard.go`: Handling for serialization of json blobs where the value is a pointer to a pointer to null.
- `query/hydrate.go`: Handling hydration of field properties which are pointers.

# Related PR
https://github.com/skuid/warden/pull/434