### PR TITLE
PLIN-3659: Improve Picard pointer handling

### DIFF
--- a/query/hydrate.go
+++ b/query/hydrate.go
@@ -147,20 +147,28 @@ func setFieldValue(model *reflect.Value, field tags.FieldMetadata, value interfa
 			model.FieldByName(field.GetName()).Set(reflect.ValueOf(value))
 		} else if field.GetFieldType().Kind() == reflect.Ptr {
 			switch field.GetFieldType().Elem().Kind() {
-			case reflect.Float64:
+			case reflect.Float32, reflect.Float64:
 				if f, ok := value.(float64); ok {
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&f))
+				} else if f, ok := value.(float32); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&f))
 				} else {
 					return errors.New("failed setting float64 value during query hydration")
 				}
-			case reflect.Int:
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 				if i, ok := value.(int); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&i))
-				} else if ui, ok := value.(int64); ok {
-					intValue := int(ui)
+				} else if i, ok := value.(int8); ok {
+					intValue := int(i)
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&intValue))
-				} else if ui, ok := value.(int32); ok {
-					intValue := int(ui)
+				} else if i, ok := value.(int16); ok {
+					intValue := int(i)
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&intValue))
+				} else if i, ok := value.(int32); ok {
+					intValue := int(i)
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&intValue))
+				} else if i, ok := value.(int64); ok {
+					intValue := int(i)
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&intValue))
 				} else {
 					return errors.New("failed setting int value during query hydration")

--- a/query/hydrate.go
+++ b/query/hydrate.go
@@ -151,7 +151,7 @@ func setFieldValue(model *reflect.Value, field tags.FieldMetadata, value interfa
 				if f, ok := value.(float64); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&f))
 				} else {
-					// Error handling
+					return errors.New("failed setting float64 value during query hydration")
 				}
 			case reflect.Int:
 				if i, ok := value.(int); ok {
@@ -160,19 +160,19 @@ func setFieldValue(model *reflect.Value, field tags.FieldMetadata, value interfa
 					intValue := int(ui)
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&intValue))
 				} else {
-					// Error handling
+					return errors.New("failed setting int value during query hydration")
 				}
 			case reflect.String:
 				if s, ok := value.(string); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&s))
 				} else {
-					// Error handling
+					return errors.New("failed setting string value during query hydration")
 				}
 			case reflect.Bool:
 				if b, ok := value.(bool); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&b))
 				} else {
-					// Error handling
+					return errors.New("failed setting bool value during query hydration")
 				}
 			}
 		}

--- a/query/hydrate.go
+++ b/query/hydrate.go
@@ -150,18 +150,29 @@ func setFieldValue(model *reflect.Value, field tags.FieldMetadata, value interfa
 			case reflect.Float64:
 				if f, ok := value.(float64); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&f))
+				} else {
+					// Error handling
 				}
 			case reflect.Int:
 				if i, ok := value.(int); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&i))
+				} else if ui, ok := value.(int64); ok {
+					intValue := int(ui)
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&intValue))
+				} else {
+					// Error handling
 				}
 			case reflect.String:
 				if s, ok := value.(string); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&s))
+				} else {
+					// Error handling
 				}
 			case reflect.Bool:
 				if b, ok := value.(bool); ok {
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&b))
+				} else {
+					// Error handling
 				}
 			}
 		}

--- a/query/hydrate.go
+++ b/query/hydrate.go
@@ -159,6 +159,9 @@ func setFieldValue(model *reflect.Value, field tags.FieldMetadata, value interfa
 				} else if ui, ok := value.(int64); ok {
 					intValue := int(ui)
 					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&intValue))
+				} else if ui, ok := value.(int32); ok {
+					intValue := int(ui)
+					model.FieldByName(field.GetName()).Set(reflect.ValueOf(&intValue))
 				} else {
 					return errors.New("failed setting int value during query hydration")
 				}


### PR DESCRIPTION
# Issue Link
https://skuidify.atlassian.net/browse/PLIN-3659

# High-Level Description
In SkuidDb, `number` and other display types that have scale and precision properties, were missing those properties. This was because those properties were `int64`s and Picard did not handle pointers to `int64`s. This PR adds handling for pointers to `int64`s, and improves the error handling for other unhandled types.

# Testing
- Create a Skuid database object field of type number.
- Open the network tab and reload the page, and look for the request `GET {{dataservice_host}}/api/v2/datasources/{{ds_id}}/entities/{{entity}}`. Find the field in `fields` and confirm that `scale` and `precision` are `null`.
- Checkout this branch in your Picard repository, and update Warden to use your local Picard in the `go.mod` file.
- Reload the page, and confirm the field now contains the `scale` and `precision` properties.

# Changelog:
- `query/hydrate.go`: Handling for pointers to `int64`, and improved error handling.
