### PR TITLE
PLIN-4034 Lookups for deletes on upserts

### DIFF
--- a/picard_test.go
+++ b/picard_test.go
@@ -162,6 +162,7 @@ func TestDeployments(t *testing.T) {
 				helper := testObjectWithPKHelper
 				returnData := GetReturnDataForLookup(helper, nil)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectInsert(mock, helper, helper.GetInsertDBColumns(true), [][]driver.Value{
 					[]driver.Value{
@@ -191,6 +192,8 @@ func TestDeployments(t *testing.T) {
 				helper := testObjectWithPKHelper
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -215,6 +218,7 @@ func TestDeployments(t *testing.T) {
 				helper := testObjectHelper
 				returnData := GetReturnDataForLookup(helper, nil)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectInsert(mock, helper, helper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -243,6 +247,8 @@ func TestDeployments(t *testing.T) {
 				helper := testObjectHelper
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -282,6 +288,8 @@ func TestDeployments(t *testing.T) {
 					},
 				}
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -307,6 +315,7 @@ func TestDeployments(t *testing.T) {
 				helper := testObjectHelper
 				returnData := GetReturnDataForLookup(helper, nil)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectInsert(mock, helper, helper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -348,6 +357,8 @@ func TestDeployments(t *testing.T) {
 				helper := testObjectHelper
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string), returnData[1][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -383,6 +394,8 @@ func TestDeployments(t *testing.T) {
 					fixtures[0],
 				})
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -438,6 +451,7 @@ func TestDeployments(t *testing.T) {
 
 				testReturnData := GetReturnDataForLookup(testObjectHelper, nil)
 				testLookupKeys := GetLookupKeys(testObjectHelper, testObjects)
+				ExpectLookupNegated(mock, testObjectHelper, testLookupKeys, testReturnData)
 				ExpectLookup(mock, testObjectHelper, testLookupKeys, testReturnData)
 
 				childInsertRows := ExpectInsert(mock, testObjectHelper, testObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
@@ -466,6 +480,7 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, nil)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectInsert(mock, testChildObjectHelper, testChildObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -488,6 +503,7 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObject)
 				returnData := GetReturnDataForLookup(testObjectHelper, nil)
 				lookupKeys := GetLookupKeys(testObjectHelper, fixtures)
+				ExpectLookupNegated(mock, testObjectHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testObjectHelper, lookupKeys, returnData)
 				insertRows := ExpectInsert(mock, testObjectHelper, testObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -515,6 +531,7 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, nil)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectInsert(mock, testChildObjectHelper, testChildObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -544,6 +561,7 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObject)
 				returnData := GetReturnDataForLookup(testObjectHelper, nil)
 				lookupKeys := GetLookupKeys(testObjectHelper, fixtures)
+				ExpectLookupNegated(mock, testObjectHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testObjectHelper, lookupKeys, returnData)
 				insertRows := ExpectInsert(mock, testObjectHelper, testObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -573,6 +591,10 @@ func TestDeployments(t *testing.T) {
 				childLookupKeysBatch1 := GetLookupKeys(testChildObjectHelper, []testdata.ChildTestObject{
 					childObjects[0],
 				})
+				childLookupKeysBatch2 := GetLookupKeys(testChildObjectHelper, []testdata.ChildTestObject{
+					childObjects[1],
+				})
+				ExpectLookupNegated(mock, testChildObjectHelper, append(childLookupKeysBatch1, childLookupKeysBatch2...), childReturnData)
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeysBatch1, childReturnData)
 				ExpectInsert(mock, testChildObjectHelper, testChildObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -582,9 +604,6 @@ func TestDeployments(t *testing.T) {
 						testChildObjectHelper.GetFixtureValue(childObjects, 0, "ParentID"),
 						nil,
 					},
-				})
-				childLookupKeysBatch2 := GetLookupKeys(testChildObjectHelper, []testdata.ChildTestObject{
-					childObjects[1],
 				})
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeysBatch2, childReturnData)
 				ExpectInsert(mock, testChildObjectHelper, testChildObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
@@ -608,6 +627,7 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObjectWithOrphans)
 				returnData := GetReturnDataForLookup(testObjectHelper, nil)
 				lookupKeys := GetLookupKeys(testObjectHelper, fixtures)
+				ExpectLookupNegated(mock, testObjectHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testObjectHelper, lookupKeys, returnData)
 				insertRows := ExpectInsert(mock, testObjectHelper, testObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -635,6 +655,7 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, nil)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectInsert(mock, testChildObjectHelper, testChildObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -664,6 +685,7 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObject)
 				returnData := GetReturnDataForLookup(testObjectHelper, nil)
 				lookupKeys := GetLookupKeys(testObjectHelper, fixtures)
+				ExpectLookupNegated(mock, testObjectHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testObjectHelper, lookupKeys, returnData)
 				insertRows := ExpectInsert(mock, testObjectHelper, testObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -691,6 +713,7 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, nil)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectInsert(mock, testChildObjectHelper, testChildObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -716,6 +739,8 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObject)
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -738,6 +763,7 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, nil)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectInsert(mock, testChildObjectHelper, testChildObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
 					[]driver.Value{
@@ -768,6 +794,8 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObjectWithOrphans)
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, testObjectHelper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, testObjectHelper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -793,6 +821,7 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, nil)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				// Expect the normal lookup
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 
@@ -848,6 +877,8 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObjectWithOrphans)
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -873,6 +904,7 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, nil)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				// Expect the normal lookup
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectInsert(mock, testChildObjectHelper, testChildObjectHelper.GetInsertDBColumns(false), [][]driver.Value{
@@ -946,6 +978,8 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObject)
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -968,6 +1002,8 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, childObjects)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
+				ExpectDelete(mock, testChildObjectHelper, []string{childReturnData[0][0].(string), childReturnData[1][0].(string)})
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 				ExpectUpdate(mock, testChildObjectHelper, [][]string{
 					testChildObjectHelper.GetUpdateDBColumnsForFixture(childObjects, 0),
@@ -995,6 +1031,8 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObjectWithOrphans)
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -1020,6 +1058,8 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, childObjects)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
+				ExpectDelete(mock, testChildObjectHelper, []string{childReturnData[0][0].(string), childReturnData[1][0].(string)})
 				// Expect the normal lookup
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 
@@ -1091,6 +1131,8 @@ func TestDeployments(t *testing.T) {
 				fixtures := fixturesAbstract.([]testdata.TestObjectWithOrphans)
 				returnData := GetReturnDataForLookup(helper, fixtures)
 				lookupKeys := GetLookupKeys(helper, fixtures)
+				ExpectLookupNegated(mock, helper, lookupKeys, returnData)
+				ExpectDelete(mock, helper, []string{returnData[0][0].(string), returnData[1][0].(string)})
 				ExpectLookup(mock, helper, lookupKeys, returnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(fixtures, 0),
@@ -1123,6 +1165,13 @@ func TestDeployments(t *testing.T) {
 
 				childReturnData := GetReturnDataForLookup(testChildObjectHelper, childObjects)
 				childLookupKeys := GetLookupKeys(testChildObjectHelper, childObjects)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnData)
+				ExpectDelete(mock, testChildObjectHelper, []string{
+					childReturnData[0][0].(string),
+					childReturnData[1][0].(string),
+					childReturnData[2][0].(string),
+					childReturnData[3][0].(string),
+				})
 				// Expect the normal lookup
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeys, childReturnData)
 
@@ -1224,6 +1273,8 @@ func TestDeployments(t *testing.T) {
 				parentIDs := []string{}
 				childObjects := []testdata.ChildTestObject{}
 
+				ExpectLookupNegated(mock, helper, append(batch1LookupKeys, batch2LookupKeys...), batch1ReturnData)
+				ExpectDelete(mock, helper, []string{batch1ReturnData[0][0].(string)})
 				ExpectLookup(mock, helper, batch1LookupKeys, batch1ReturnData)
 				ExpectUpdate(mock, helper, [][]string{
 					helper.GetUpdateDBColumnsForFixture(batch1Fixtures, 0),
@@ -1287,7 +1338,11 @@ func TestDeployments(t *testing.T) {
 				childLookupKeysBatch3 := GetLookupKeys(testChildObjectHelper, batch3ChildFixtures)
 				childReturnDataBatch4 := GetReturnDataForLookup(testChildObjectHelper, batch4ChildFixtures)
 				childLookupKeysBatch4 := GetLookupKeys(testChildObjectHelper, batch4ChildFixtures)
-
+				childLookupKeys := append(childLookupKeysBatch1, childLookupKeysBatch2...)
+				childLookupKeys = append(childLookupKeys, childLookupKeysBatch3...)
+				childLookupKeys = append(childLookupKeys, childLookupKeysBatch4...)
+				ExpectLookupNegated(mock, testChildObjectHelper, childLookupKeys, childReturnDataBatch1)
+				ExpectDelete(mock, testChildObjectHelper, []string{childReturnDataBatch1[0][0].(string)})
 				// Expect the normal lookup
 				ExpectLookup(mock, testChildObjectHelper, childLookupKeysBatch1, childReturnDataBatch1)
 
@@ -1405,6 +1460,8 @@ func TestDeployments(t *testing.T) {
 					},
 				}
 
+				ExpectLookupNegated(mock, testChildObjectWithLookupHelper, []string{"ChildItem|Simple|"}, returnData)
+				ExpectDelete(mock, testChildObjectHelper, []string{returnData[0][0].(string)})
 				ExpectLookup(mock, testChildObjectWithLookupHelper, []string{"ChildItem|Simple|"}, returnData)
 
 				// Expect the foreign key lookup next
@@ -1449,6 +1506,7 @@ func TestDeployments(t *testing.T) {
 					})
 				}
 
+				ExpectLookupNegated(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 
 				// Expect the foreign key lookup next
@@ -1491,6 +1549,7 @@ func TestDeployments(t *testing.T) {
 					})
 				}
 
+				ExpectLookupNegated(mock, testChildObjectHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testChildObjectHelper, lookupKeys, returnData)
 
 				// Expect the foreign key lookup next
@@ -1535,6 +1594,7 @@ func TestDeployments(t *testing.T) {
 					})
 				}
 
+				ExpectLookupNegated(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 
 				// Expect the foreign key lookup next
@@ -1576,6 +1636,7 @@ func TestDeployments(t *testing.T) {
 				lookupKeys := []string{"ChildItem|Simple|"}
 				returnData := [][]driver.Value{}
 
+				ExpectLookupNegated(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 
 				// Expect the foreign key lookup next
@@ -1593,6 +1654,7 @@ func TestDeployments(t *testing.T) {
 				lookupKeys := []string{"ChildItem|Simple|", "ChildItem2|Simple2|"}
 				returnData := [][]driver.Value{}
 
+				ExpectLookupNegated(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 
 				// Expect the foreign key lookup next
@@ -1610,6 +1672,7 @@ func TestDeployments(t *testing.T) {
 				lookupKeys := []string{"ChildItem|Simple|"}
 				returnData := [][]driver.Value{}
 
+				ExpectLookupNegated(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 				ExpectLookup(mock, testChildObjectWithLookupHelper, lookupKeys, returnData)
 
 				// Expect the foreign key lookup next
@@ -1638,6 +1701,7 @@ func TestDeployments(t *testing.T) {
 				})
 				junctionLookupKeys := []string{"George|Fred"}
 
+				ExpectLookupNegated(mock, junctionHelper, junctionLookupKeys, junctionReturnData)
 				ExpectLookup(mock, junctionHelper, junctionLookupKeys, junctionReturnData)
 
 				ExpectLookup(mock, personHelper, []string{"George"}, personReturnData1)
@@ -1679,6 +1743,7 @@ func TestDeployments(t *testing.T) {
 				})
 				junctionLookupKeys := []string{"|Fred"}
 
+				ExpectLookupNegated(mock, junctionHelper, junctionLookupKeys, junctionReturnData)
 				ExpectLookup(mock, junctionHelper, junctionLookupKeys, junctionReturnData)
 
 				ExpectLookup(mock, personWithPKHelper, []string{"00000000-0000-0000-0000-000000C0FFEE"}, personReturnData1)
@@ -1713,6 +1778,7 @@ func TestDeployments(t *testing.T) {
 
 				junctionLookupKeys := []string{"00000000-0000-0000-0000-000000C0FFEE|Fred"}
 
+				ExpectLookupNegated(mock, junctionHelper, junctionLookupKeys, junctionReturnData)
 				ExpectLookup(mock, junctionHelper, junctionLookupKeys, junctionReturnData)
 
 				ExpectLookup(mock, personHelper, []string{"Fred"}, personReturnData1)
@@ -1732,6 +1798,9 @@ func TestDeployments(t *testing.T) {
 
 	// Run first with the default batch size
 	for _, c := range cases {
+		// if c.TestName != "Test name" { // uncomment to test single cases
+		// 	continue
+		// }
 		t.Run(c.TestName, func(t *testing.T) {
 			fixtures, err := loadTestObjects(c.FixtureNames, c.FixtureType)
 			if err != nil {

--- a/testing.go
+++ b/testing.go
@@ -267,9 +267,32 @@ func ExpectLookup(mock *sqlmock.Sqlmock, expect ExpectationHelper, lookupKeys []
 	(*mock).ExpectQuery(expectSQL).WithArgs(expectedArgs...).WillReturnRows(returnRows)
 }
 
+func ExpectLookupNegated(mock *sqlmock.Sqlmock, expect ExpectationHelper, lookupKeys []string, returnData [][]driver.Value) {
+	expectNegated := expect
+	expectNegated.LookupWhere = "NOT " + expectNegated.LookupWhere
+	ExpectLookup(mock, expectNegated, lookupKeys, returnData)
+}
+
 // ExpectQuery is just a wrapper around sqlmock
 func ExpectQuery(mock *sqlmock.Sqlmock, expectSQL string) *sqlmock.ExpectedQuery {
 	return (*mock).ExpectQuery(expectSQL)
+}
+
+type VerifyArgs struct {
+	values []string
+}
+
+func (a VerifyArgs) Match(v driver.Value) bool {
+	actual, ok := v.(string)
+	if !ok {
+		return false
+	}
+	for _, expected := range a.values {
+		if actual == expected {
+			return true
+		}
+	}
+	return false
 }
 
 // ExpectDelete Mocks a delete request to the database.
@@ -282,13 +305,26 @@ func ExpectDelete(mock *sqlmock.Sqlmock, expect ExpectationHelper, expectedIDs [
 	expectSQL := `
 		DELETE FROM ` + expect.getTableName() + `
 		WHERE ` + deletePKField + ` IN \(` + strings.Join(valueParams, ",") + `\) AND organization_id = \$` + strconv.Itoa(len(expectedIDs)+1)
+	expectedArgs := append(expectedIDs, sampleOrgID)
 
-	expectedArgs := []driver.Value{}
-	for _, ID := range expectedIDs {
-		expectedArgs = append(expectedArgs, ID)
+	exec := (*mock).ExpectExec(expectSQL)
+
+	// doing this because WithArgs doesn't accept custom interfaces in a variadic way
+	// either way, it shouldn't be a major problem because of unit tests using static size arrays
+	switch len(expectedIDs) {
+	case 1:
+		exec = exec.WithArgs(VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs})
+	case 2:
+		exec = exec.WithArgs(VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs})
+	case 3:
+		exec = exec.WithArgs(VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs})
+	case 4:
+		exec = exec.WithArgs(VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs}, VerifyArgs{expectedArgs})
+	default:
+		exec = exec.WithArgs(VerifyArgs{expectedArgs})
 	}
-	expectedArgs = append(expectedArgs, sampleOrgID)
-	(*mock).ExpectExec(expectSQL).WithArgs(expectedArgs...).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	exec.WillReturnResult(sqlmock.NewResult(1, 1))
 	return nil
 }
 


### PR DESCRIPTION
When doing an `upsert`, the new rows are being inserted before deleting old ones that shouldn't exist anymore. This is a problem because there might be an issue with unique keys on the DB ([e.g.](https://github.com/skuid/warden/pull/519#pullrequestreview-1164013754)). With this PR a query will be executed to retrieve the items that should be deleted, and execute the generated statements before the inserts and updates.

### Issue: [PLIN-4034](https://inflight.atlassian.net/browse/PLIN-4034)

### To test

Play with upserts of items that have unique key constraints on its table and make sure no `duplicate key value` errors arise.

[PLIN-4034]: https://inflight.atlassian.net/browse/PLIN-4034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ