### PR TITLE
PLIN-4268 add since flag

### DIFF
--- a/tags/tags.go
+++ b/tags/tags.go
@@ -235,8 +235,9 @@ SQL translation in WHERE clause grouping:
 	t0.field_B = "bar"
 */
 type FieldFilter struct {
-	FieldName   string
-	FilterValue interface{}
+	FieldName      string
+	FilterValue    interface{}
+	FilterOperator string
 }
 
 // Apply applies the filter
@@ -247,7 +248,19 @@ func (ff FieldFilter) Apply(table *qp.Table, metadata *TableMetadata) squirrel.S
 	}
 	fieldMetadata := metadata.GetField(ff.FieldName)
 	columnName := fieldMetadata.GetColumnName()
-	return squirrel.Eq{fmt.Sprintf(qp.AliasedField, table.Alias, columnName): ff.FilterValue}
+	expr := fmt.Sprintf(qp.AliasedField, table.Alias, columnName)
+	switch ff.FilterOperator {
+	case "<":
+		return squirrel.Lt{expr: ff.FilterValue}
+	case "<=":
+		return squirrel.LtOrEq{expr: ff.FilterValue}
+	case ">":
+		return squirrel.Gt{expr: ff.FilterValue}
+	case ">=":
+		return squirrel.GtOrEq{expr: ff.FilterValue}
+	default:
+		return squirrel.Eq{expr: ff.FilterValue}
+	}
 }
 
 // OrFilterGroup applies a group of filters using ors
@@ -270,6 +283,11 @@ func (afg AndFilterGroup) Apply(table *qp.Table, metadata *TableMetadata) squirr
 	ands := squirrel.And{}
 	for _, filter := range afg {
 		ands = append(ands, filter.Apply(table, metadata))
+	}
+	ats, args, _ := ands.ToSql()
+	fmt.Println(ats)
+	for _, v := range args {
+		fmt.Printf("%v\n", v)
 	}
 	return ands
 }

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -284,11 +284,6 @@ func (afg AndFilterGroup) Apply(table *qp.Table, metadata *TableMetadata) squirr
 	for _, filter := range afg {
 		ands = append(ands, filter.Apply(table, metadata))
 	}
-	ats, args, _ := ands.ToSql()
-	fmt.Println(ats)
-	for _, v := range args {
-		fmt.Printf("%v\n", v)
-	}
 	return ands
 }
 


### PR DESCRIPTION
# Issue Link
https://inflight.atlassian.net/browse/PLIN-4268

# High-Level Description
Adds picard support for more `squirrel` operators on a FieldFilter than `==`/`Eq`. This is currently needed to support returning records with audit data 'UpdatedAt' fields after a given datetime (i.e. implementing a "since" option for Skuid site retrieve).

# Changelog:

- 
