### PR TITLE
AB#516284 Add null filter to support container filtering in warden

### DIFF
--- a/tags/tags.go
+++ b/tags/tags.go
@@ -263,6 +263,51 @@ func (ff FieldFilter) Apply(table *qp.Table, metadata *TableMetadata) squirrel.S
 	}
 }
 
+/*
+	NullFilter defines a filter that generates IS NULL or IS NOT NULL conditions.
+
+Example:
+
+	import "github.com/skuid/picard/tags"
+
+	tags.NullFilter{
+		FieldName: "ContainerID",
+		IsNull:    true,
+	}
+
+SQL translation in WHERE clause grouping:
+
+	t0.container_id IS NULL
+
+When IsNull is false:
+
+	t0.container_id IS NOT NULL
+*/
+type NullFilter struct {
+	FieldName string
+	IsNull    bool
+}
+
+// Apply applies the null filter, producing IS NULL or IS NOT NULL
+func (nf NullFilter) Apply(table *qp.Table, metadata *TableMetadata) squirrel.Sqlizer {
+	// Return early if no fieldname was provided in our filter
+	if nf.FieldName == "" {
+		return squirrel.Eq{}
+	}
+	fieldMetadata := metadata.GetField(nf.FieldName)
+	columnName := fieldMetadata.GetColumnName()
+	if columnName == "" {
+		return squirrel.Eq{}
+	}
+	expr := fmt.Sprintf(qp.AliasedField, table.Alias, columnName)
+	if nf.IsNull {
+		// squirrel.Eq{"column": nil} produces "column IS NULL"
+		return squirrel.Eq{expr: nil}
+	}
+	// squirrel.NotEq{"column": nil} produces "column IS NOT NULL"
+	return squirrel.NotEq{expr: nil}
+}
+
 // OrFilterGroup applies a group of filters using ors
 type OrFilterGroup []Filterable
 

--- a/tags/tags_test.go
+++ b/tags/tags_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/skuid/picard/metadata"
+	qp "github.com/skuid/picard/queryparts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -174,4 +175,123 @@ func TestGetStructTagsMap(t *testing.T) {
 			assert.Equal(t, resultMap, tc.wantMap)
 		})
 	}
+}
+
+type NullFilterTestModel struct {
+	metadata.Metadata `picard:"tablename=test_table"`
+	ID                string  `picard:"primary_key,column=id"`
+	ContainerID       *string `picard:"column=container_id"`
+	Name              string  `picard:"column=name"`
+}
+
+func nullFilterTestTable() (*qp.Table, *TableMetadata) {
+	table := qp.New("test_table")
+	tm := TableMetadataFromType(reflect.TypeOf(NullFilterTestModel{}))
+	return table, tm
+}
+
+func TestNullFilter_IsNull(t *testing.T) {
+	table, tm := nullFilterTestTable()
+
+	filter := NullFilter{
+		FieldName: "ContainerID",
+		IsNull:    true,
+	}
+
+	result := filter.Apply(table, tm)
+	sql, args, err := result.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, table.Alias+".container_id IS NULL", sql)
+	assert.Empty(t, args)
+}
+
+func TestNullFilter_IsNotNull(t *testing.T) {
+	table, tm := nullFilterTestTable()
+
+	filter := NullFilter{
+		FieldName: "ContainerID",
+		IsNull:    false,
+	}
+
+	result := filter.Apply(table, tm)
+	sql, args, err := result.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, table.Alias+".container_id IS NOT NULL", sql)
+	assert.Empty(t, args)
+}
+
+func TestNullFilter_EmptyFieldName(t *testing.T) {
+	table, tm := nullFilterTestTable()
+
+	filter := NullFilter{
+		FieldName: "",
+		IsNull:    true,
+	}
+
+	result := filter.Apply(table, tm)
+	sql, args, err := result.ToSql()
+	assert.NoError(t, err)
+	// Empty Eq{} produces empty SQL
+	assert.Empty(t, sql)
+	assert.Empty(t, args)
+}
+
+func TestNullFilter_InvalidFieldName(t *testing.T) {
+	table, tm := nullFilterTestTable()
+
+	filter := NullFilter{
+		FieldName: "NonExistentField",
+		IsNull:    true,
+	}
+
+	result := filter.Apply(table, tm)
+	// Should return empty Eq{} since field doesn't exist (columnName is "")
+	sql, args, err := result.ToSql()
+	assert.NoError(t, err)
+	assert.Empty(t, sql)
+	assert.Empty(t, args)
+}
+
+func TestNullFilter_ComposableWithOrFilterGroup(t *testing.T) {
+	table, tm := nullFilterTestTable()
+
+	filter := OrFilterGroup{
+		NullFilter{
+			FieldName: "ContainerID",
+			IsNull:    true,
+		},
+		NullFilter{
+			FieldName: "ContainerID",
+			IsNull:    false,
+		},
+	}
+
+	result := filter.Apply(table, tm)
+	sql, args, err := result.ToSql()
+	assert.NoError(t, err)
+	assert.Contains(t, sql, "container_id IS NULL")
+	assert.Contains(t, sql, "container_id IS NOT NULL")
+	assert.Empty(t, args)
+}
+
+func TestNullFilter_ComposableWithAndFilterGroup(t *testing.T) {
+	table, tm := nullFilterTestTable()
+
+	filter := AndFilterGroup{
+		NullFilter{
+			FieldName: "ContainerID",
+			IsNull:    true,
+		},
+		FieldFilter{
+			FieldName:   "Name",
+			FilterValue: "test",
+		},
+	}
+
+	result := filter.Apply(table, tm)
+	sql, args, err := result.ToSql()
+	assert.NoError(t, err)
+	assert.Contains(t, sql, "container_id IS NULL")
+	assert.Contains(t, sql, "name")
+	assert.Contains(t, args, "test")
 }


### PR DESCRIPTION
# Issue Link
https://dev.azure.com/nintex/Nintex/_workitems/edit/516284

# High-Level Description
Add the ability to filter on null field values so can get list of objects where container_id is null in warden

# Linked PRs:
https://github.com/skuid/skuid-monorepo/pull/14430
https://github.com/skuid/warden/pull/874
